### PR TITLE
Add link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ A curated list of awesome streamlit resources. Inspired by [awesome-python](http
 - [Sentiment Analyzer Tool](https://www.linkedin.com/posts/patidarparas13_code-ml-machinelearning-ugcPost-6585745929062703104-ttkv) (#App, #Code, #Social)
 - [Streamlit Demo](https://github.com/Poseyy/StreamlitDemo) by [Luke Posey](https://github.com/Poseyy) (#App, #Code)
 - [Streamlit-components-demo App](https://fullstackstation.com/streamlit-components-demo) (#App)
+- [Deploying web apps with Streamlit, Docker, and AWS](https://github.com/collinprather/streamlit-docker/tree/docker-compose+postgres) by [Collin Prather](https://github.com/collinprather) (#App, #Code)
 
 ### Article
 

--- a/package/awesome_streamlit/database/authors.py
+++ b/package/awesome_streamlit/database/authors.py
@@ -38,6 +38,7 @@ DAVID_CHEDZICKI = Author(
     # github_avatar_url="https://avatars1.githubusercontent.com/u/1222726",
 )
 ESTEE_TEY = Author(name="Tey Siew Wen", url="https://github.com/lyqht")
+COLLIN_PRATHER = Author(name="Collin Prather", url="https://github.com/collinprather")
 
 AUTHORS = [
     ALEXANDRE_DOMINGUES,

--- a/package/awesome_streamlit/database/resources.py
+++ b/package/awesome_streamlit/database/resources.py
@@ -667,6 +667,13 @@ RESOURCES = (
             tags=[CODE],
             is_awesome=True,
         ),
+        Resource(
+            name="Deploying wed apps with Streamlit, Docker, and AWS",
+            url="https://github.com/collinprather/streamlit-docker/tree/docker-compose+postgres",
+            is_awesome=True,
+            tags=[tags.APP, tags.CODE],
+            author=authors.COLLIN_PRATHER,
+        ),
     ]
     + STREAMLIT_EXAMPLE_APPS
     + STREAMLIT_EXAMPLE_APPS_FAILED_TEST


### PR DESCRIPTION
I would like to add a link to [this repository](https://github.com/collinprather/streamlit-docker/tree/docker-compose+postgres) in the `README.MD`, as it provides a comprehensive example for deploying an ML model with Streamlit, using Docker and AWS. In addition, this shows users how to use `docker-compose` to add a postgres database to the backend of the app. There is also a 3-part tutorial (linked in the repository) which explains how each of these technologies work in tandem.

This pull request has made the following changes:
1. Added a link to the `README.MD`
2. Added this resource in the `package/awesome_streamlit/database/resources.py` file.
3. Added myself as an author in the `package/awesome_streamlit/database/authors.py` file.

Thank you!